### PR TITLE
Add Log4jFilter to deny 'moved wrongly' messages

### DIFF
--- a/src/main/java/net/xalcon/chococraft/Chococraft.java
+++ b/src/main/java/net/xalcon/chococraft/Chococraft.java
@@ -1,5 +1,8 @@
 package net.xalcon.chococraft;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.EnumCreatureType;
 import net.minecraft.item.ItemStack;
@@ -7,8 +10,6 @@ import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.SidedProxy;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
@@ -23,8 +24,7 @@ import net.xalcon.chococraft.common.entities.properties.EntityDataSerializers;
 import net.xalcon.chococraft.common.init.ModItems;
 import net.xalcon.chococraft.common.network.PacketManager;
 import net.xalcon.chococraft.common.world.worldgen.WorldGenGysahlGreen;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import net.xalcon.chococraft.utils.Log4jFilter;
 
 @Mod(modid = Chococraft.MODID, version = Chococraft.VERSION, acceptedMinecraftVersions = Chococraft.MC_VERSION)
 public class Chococraft
@@ -61,6 +61,7 @@ public class Chococraft
         NetworkRegistry.INSTANCE.registerGuiHandler(instance, new ChococraftGuiHandler());
         EntityDataSerializers.init();
         PacketManager.init();
+        Log4jFilter.init();
 
         GameRegistry.registerWorldGenerator(new WorldGenGysahlGreen(), ChocoConfig.world.gysahlGreenSpawnWeight);
 

--- a/src/main/java/net/xalcon/chococraft/utils/Log4jFilter.java
+++ b/src/main/java/net/xalcon/chococraft/utils/Log4jFilter.java
@@ -1,0 +1,159 @@
+package net.xalcon.chococraft.utils;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.message.Message;
+
+public class Log4jFilter implements Filter
+{
+
+    @Override
+    public Filter.Result filter(LogEvent event)
+    {
+        Message m = event.getMessage();
+        if (m.toString().contains("moved wrongly") || m.getFormattedMessage().contains("moved wrongly")) {
+            return Filter.Result.DENY;
+        }
+        return null;
+    }
+
+	@Override
+	public State getState()
+    {
+        return null;
+    }
+
+    @Override
+    public void initialize()
+    {
+    }
+
+    @Override
+    public void start()
+    {
+    }
+
+    @Override
+    public void stop()
+    {
+    }
+
+    @Override
+    public boolean isStarted()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isStopped()
+    {
+        return false;
+    }
+
+    @Override
+    public Result getOnMismatch()
+    {
+        return null;
+    }
+
+    @Override
+    public Result getOnMatch()
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String msg, Object... params)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0)
+	{
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+            Object p3)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+            Object p3, Object p4)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+            Object p3, Object p4, Object p5)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+            Object p3, Object p4, Object p5, Object p6)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+            Object p3, Object p4, Object p5, Object p6, Object p7)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+            Object p3, Object p4, Object p5, Object p6, Object p7, Object p8)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+            Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t)
+    {
+        return null;
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, Message msg, Throwable t)
+    {
+        return null;
+    }
+
+    public static void init()
+    {
+        ((Logger) LogManager.getRootLogger()).addFilter(new Log4jFilter());
+    }
+
+}


### PR DESCRIPTION
Fixes [Xalcon/ChocoCraft3 #13](https://github.com/Xalcon/ChocoCraft3/issues/13). As of right now, all "moved wrongly" messages will be denied, which is probably too strict. You may want to narrow that down to just the Chocobo messages.